### PR TITLE
fix(internal): change parameter order

### DIFF
--- a/internal/rules/interfaces.go
+++ b/internal/rules/interfaces.go
@@ -11,6 +11,6 @@ type ResourcesInterface interface {
 
 	IsAllowed(resource string, operation string) Access
 
-	Grant(resource string, teamID uint64, operations []string, value Access) error
-	ListGrants(resource string, teamID uint64) ([]Rules, error)
+	Grant(teamID uint64, resource string, operations []string, value Access) error
+	ListGrants(teamID uint64, resource string) ([]Rules, error)
 }

--- a/internal/rules/resources.go
+++ b/internal/rules/resources.go
@@ -99,7 +99,7 @@ func (r *resources) checkAccess(resource string, operation string) Access {
 	return Inherit
 }
 
-func (r *resources) Grant(resource string, teamID uint64, operations []string, value Access) error {
+func (r *resources) Grant(teamID uint64, resource string, operations []string, value Access) error {
 	row := Rules{
 		TeamID:   teamID,
 		Resource: resource,
@@ -122,7 +122,7 @@ func (r *resources) Grant(resource string, teamID uint64, operations []string, v
 	return err
 }
 
-func (r *resources) ListGrants(resource string, teamID uint64) ([]Rules, error) {
+func (r *resources) ListGrants(teamID uint64, resource string) ([]Rules, error) {
 	result := []Rules{}
 
 	query := "select * from sys_rules where rel_team = ? and resource = ?"

--- a/internal/rules/resources_test.go
+++ b/internal/rules/resources_test.go
@@ -45,7 +45,7 @@ func TestRules(t *testing.T) {
 
 		// allow channel:2 group:2 (default deny, multi=allow)
 		{
-			resources.Grant("channel:2", 2, []string{"edit", "delete"}, rules.Allow)
+			resources.Grant(2, "channel:2", []string{"edit", "delete"}, rules.Allow)
 			Expect(rules.Inherit, resources.IsAllowed("channel:1", "edit"), "expected error, got nil")
 			Expect(rules.Allow, resources.IsAllowed("channel:2", "edit"), "channel:2 edit, expected no error")
 			Expect(rules.Allow, resources.IsAllowed("channel:*", "edit"), "channel:* edit, expected no error")
@@ -53,7 +53,7 @@ func TestRules(t *testing.T) {
 
 		// list grants for team
 		{
-			grants, err := resources.ListGrants("channel:2", 2)
+			grants, err := resources.ListGrants(2, "channel:2")
 			NoError(t, err, "expect no error")
 			Assert(t, len(grants) == 2, "expected 2 grants")
 			Assert(t, grants[0].TeamID == 2, "expected TeamID == 2, got %v", grants[0].TeamID)
@@ -64,7 +64,7 @@ func TestRules(t *testing.T) {
 
 		// deny channel:1 group:1 (explicit deny, multi=deny)
 		{
-			resources.Grant("channel:1", 1, []string{"edit"}, rules.Deny)
+			resources.Grant(1, "channel:1", []string{"edit"}, rules.Deny)
 			Expect(rules.Deny, resources.IsAllowed("channel:1", "edit"), "expected error, got nil")
 			Expect(rules.Allow, resources.IsAllowed("channel:2", "edit"), "channel:2 edit, expected no error")
 			Expect(rules.Deny, resources.IsAllowed("channel:*", "edit"), "expected error, got nil")
@@ -72,8 +72,8 @@ func TestRules(t *testing.T) {
 
 		// reset (unset=deny)
 		{
-			resources.Grant("channel:2", 2, []string{"edit", "delete"}, rules.Inherit)
-			resources.Grant("channel:1", 1, []string{"edit", "delete"}, rules.Inherit)
+			resources.Grant(2, "channel:2", []string{"edit", "delete"}, rules.Inherit)
+			resources.Grant(1, "channel:1", []string{"edit", "delete"}, rules.Inherit)
 			Expect(rules.Inherit, resources.IsAllowed("channel:1", "edit"), "expected error, got nil")
 			Expect(rules.Inherit, resources.IsAllowed("channel:*", "edit"), "expected error, got nil")
 		}


### PR DESCRIPTION
```   
   * change parameter order for Grant, ListGrants (teamID should be first param)

Simple ordering fix, we're granting Teams permissions on Resource,...
```