### PR TITLE
fix(internal): rbac uses user.ID for actions

### DIFF
--- a/internal/rbac/main_test.go
+++ b/internal/rbac/main_test.go
@@ -1,15 +1,20 @@
 package rbac_test
 
 import (
-	"github.com/crusttech/crust/internal/rbac"
-	"github.com/namsral/flag"
 	"testing"
+
+	"github.com/joho/godotenv"
+	"github.com/namsral/flag"
+
+	"github.com/crusttech/crust/internal/rbac"
 )
 
 var loaded bool
 
 func getClient() (*rbac.Client, error) {
 	if !loaded {
+		godotenv.Load("../../.env")
+
 		rbac.Flags()
 		flag.Parse()
 		loaded = true

--- a/internal/rbac/resources.go
+++ b/internal/rbac/resources.go
@@ -3,8 +3,10 @@ package rbac
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/crusttech/crust/internal/rbac/types"
+
 	"github.com/pkg/errors"
+
+	"github.com/crusttech/crust/internal/rbac/types"
 )
 
 type (

--- a/internal/rbac/roles.go
+++ b/internal/rbac/roles.go
@@ -3,9 +3,11 @@ package rbac
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/crusttech/crust/internal/rbac/types"
-	"github.com/pkg/errors"
 	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/crusttech/crust/internal/rbac/types"
 )
 
 type (

--- a/internal/rbac/sessions.go
+++ b/internal/rbac/sessions.go
@@ -3,6 +3,7 @@ package rbac
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/crusttech/crust/internal/rbac/types"
 	"github.com/pkg/errors"
 )
@@ -13,7 +14,7 @@ type (
 	}
 
 	SessionsInterface interface {
-		Create(sessionID, username string, roles ...string) error
+		Create(sessionID, userID string, roles ...string) error
 		Get(sessionID string) (*types.Session, error)
 		Delete(sessionID string) error
 
@@ -30,11 +31,11 @@ const (
 	sessionsDeactivateRole = "/sessions/%s/deactivateRole"
 )
 
-func (u *Sessions) Create(sessionID, username string, roles ...string) error {
+func (u *Sessions) Create(sessionID, userID string, roles ...string) error {
 	body := struct {
-		Username string   `json:"username"`
-		Roles    []string `json:"roles,omitempty"`
-	}{username, roles}
+		UserID string   `json:"userid"`
+		Roles  []string `json:"roles,omitempty"`
+	}{userID, roles}
 
 	resp, err := u.Client.Post(fmt.Sprintf(sessionsCreate, sessionID), body)
 	if err != nil {

--- a/internal/rbac/types/structs.go
+++ b/internal/rbac/types/structs.go
@@ -2,16 +2,16 @@ package types
 
 type (
 	User struct {
-		UserID          string   `json:"userid"`
+		ID              string   `json:"userid"`
 		Username        string   `json:"username"`
 		AssignedRoles   []string `json:"assignedRoles"`
 		AuthorizedRoles []string `json:"authorizedRoles"`
 	}
 
 	Session struct {
-		ID       string   `json:"session"`
-		Username string   `json:"username"`
-		Roles    []string `json:"roles"`
+		ID     string   `json:"session"`
+		UserID string   `json:"userid"`
+		Roles  []string `json:"roles"`
 	}
 
 	// @todo: need to list nested roles,

--- a/internal/rbac/users.go
+++ b/internal/rbac/users.go
@@ -3,8 +3,10 @@ package rbac
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/crusttech/crust/internal/rbac/types"
+
 	"github.com/pkg/errors"
+
+	"github.com/crusttech/crust/internal/rbac/types"
 )
 
 type (
@@ -14,11 +16,11 @@ type (
 
 	UsersInterface interface {
 		Create(username, password string) (*types.User, error)
-		Get(username string) (*types.User, error)
-		Delete(username string) error
+		Get(userID string) (*types.User, error)
+		Delete(userID string) error
 
-		AddRole(username string, roles ...string) error
-		RemoveRole(username string, roles ...string) error
+		AddRole(userID string, roles ...string) error
+		RemoveRole(userID string, roles ...string) error
 	}
 )
 
@@ -51,12 +53,12 @@ func (u *Users) Create(username, password string) (*types.User, error) {
 	}
 }
 
-func (u *Users) AddRole(username string, roles ...string) error {
+func (u *Users) AddRole(userID string, roles ...string) error {
 	body := struct {
 		Roles []string `json:"roles"`
 	}{roles}
 
-	resp, err := u.Client.Patch(fmt.Sprintf(usersAddRole, username), body)
+	resp, err := u.Client.Patch(fmt.Sprintf(usersAddRole, userID), body)
 	if err != nil {
 		return errors.Wrap(err, "request failed")
 	}
@@ -69,12 +71,12 @@ func (u *Users) AddRole(username string, roles ...string) error {
 	}
 }
 
-func (u *Users) RemoveRole(username string, roles ...string) error {
+func (u *Users) RemoveRole(userID string, roles ...string) error {
 	body := struct {
 		Roles []string `json:"roles"`
 	}{roles}
 
-	resp, err := u.Client.Patch(fmt.Sprintf(usersRemoveRole, username), body)
+	resp, err := u.Client.Patch(fmt.Sprintf(usersRemoveRole, userID), body)
 	if err != nil {
 		return errors.Wrap(err, "request failed")
 	}
@@ -87,8 +89,8 @@ func (u *Users) RemoveRole(username string, roles ...string) error {
 	}
 }
 
-func (u *Users) Get(username string) (*types.User, error) {
-	resp, err := u.Client.Get(fmt.Sprintf(usersGet, username))
+func (u *Users) Get(userID string) (*types.User, error) {
+	resp, err := u.Client.Get(fmt.Sprintf(usersGet, userID))
 	if err != nil {
 		return nil, errors.Wrap(err, "request failed")
 	}
@@ -102,8 +104,8 @@ func (u *Users) Get(username string) (*types.User, error) {
 	}
 }
 
-func (u *Users) Delete(username string) error {
-	resp, err := u.Client.Delete(fmt.Sprintf(usersDelete, username))
+func (u *Users) Delete(userID string) error {
+	resp, err := u.Client.Delete(fmt.Sprintf(usersDelete, userID))
 	if err != nil {
 		return errors.Wrap(err, "request failed")
 	}

--- a/internal/rbac/users_test.go
+++ b/internal/rbac/users_test.go
@@ -11,49 +11,45 @@ func TestUsers(t *testing.T) {
 	users := rbac.Users()
 	roles := rbac.Roles()
 
-	users.Delete("test-user")
+	// Cleanup data
 	roles.Delete("test-role")
+	// @todo until users.Get implements getting user by email, we need to delete users at end of the test successful and unsuccessful.
 
 	must(t, roles.Create("test-role"), "Error when creating test-role")
 
-	{
-		_, err := users.Create("test-user", "test-password")
-		must(t, err, "Error when creating test-user")
-	}
+	user, err := users.Create("test-user@crust.tech", "test-password")
+	must(t, err, "Error when creating test-user")
 
 	// check if we inherited some roles (should be empty)
 	{
-		user, err := users.Get("test-user")
+		u1, err := users.Get(user.ID)
 		must(t, err, "Error when retrieving test-user 1")
-		// assert(t, user.Username == "test-user", "Unexpected username, test-user != '%s'", user.Username)
-		assert(t, len(user.AssignedRoles) == 0, "Unexpected number of roles, expected empty, got %+v", user.AssignedRoles)
+		assert(t, len(u1.AssignedRoles) == 0, "Unexpected number of roles, expected empty, got %+v", u1.AssignedRoles)
 	}
 
-	must(t, users.AddRole("test-user", "test-role"), "Error when assigning test-role to test-user")
+	must(t, users.AddRole(user.ID, "test-role"), "Error when assigning test-role to test-user")
 
 	// check if we inherited some roles (should be empty)
 	{
-		user, err := users.Get("test-user")
-		must(t, err, "Error when retrieving test-user 3")
-		// assert(t, user.Username == "test-user", "Unexpected username, test-user != '%s'", user.Username)
-		assert(t, len(user.AssignedRoles) == 1, "Unexpected number of roles, expected 1, got %+v", user.AssignedRoles)
-		assert(t, user.AssignedRoles[0] == "test-role", "Unexpected role name, test-role != '%s'", user.AssignedRoles[0])
+		u2, err := users.Get(user.ID)
+		must(t, err, "Error when retrieving test-user 2")
+		assert(t, len(u2.AssignedRoles) == 1, "Unexpected number of roles, expected 1, got %+v", u2.AssignedRoles)
+		assert(t, u2.AssignedRoles[0] == "test-role", "Unexpected role name, test-role != '%s'", u2.AssignedRoles[0])
 	}
 
-	must(t, users.RemoveRole("test-user", "test-role"), "Error when deassigning test-role to test-user")
+	must(t, users.RemoveRole(user.ID, "test-role"), "Error when de-assigning test-role to test-user")
 
 	// check roles are empty after de-assign
 	{
-		user, err := users.Get("test-user")
-		must(t, err, "Error when retrieving test-user 4")
-		// assert(t, user.Username == "test-user", "Unexpected username, test-user != '%s'", user.Username)
-		assert(t, len(user.AssignedRoles) == 0, "Unexpected number of roles, expected empty, got %+v", user.AssignedRoles)
+		u3, err := users.Get(user.ID)
+		must(t, err, "Error when retrieving test-user 3")
+		assert(t, len(u3.AssignedRoles) == 0, "Unexpected number of roles, expected empty, got %+v", u3.AssignedRoles)
 	}
 
-	must(t, users.Delete("test-user"), "Error when deleting test-user")
+	must(t, users.Delete(user.ID), "Error when deleting test-user")
 	mustFail(t, func() error {
-		_, err := users.Get("test-user")
+		_, err := users.Get(user.ID)
 		return err
 	}())
-	mustFail(t, users.Delete("test-user"))
+	mustFail(t, users.Delete(user.ID))
 }


### PR DESCRIPTION
RBAC API now uses user.ID for actions and registration username is user email.