### PR TITLE
fix(messaging): removed double permission word in path

### DIFF
--- a/api/messaging/spec.json
+++ b/api/messaging/spec.json
@@ -698,14 +698,14 @@
     "apis": [
       {
         "name": "list",
-        "path": "/permissions",
+        "path": "/",
         "method": "GET",
         "title": "List default permissions",
         "parameters": {}
       },
       {
         "name": "get",
-        "path": "/permissions/{teamID}",
+        "path": "/{teamID}",
         "method": "GET",
         "title": "Retrieve current permission settings",
         "parameters": {
@@ -729,7 +729,7 @@
       },
       {
         "name": "set",
-        "path": "/permissions/{teamID}",
+        "path": "/{teamID}",
         "method": "POST",
         "title": "Update permission settings",
         "parameters": {
@@ -753,7 +753,7 @@
       },
       {
         "name": "scopes",
-        "path": "/permissions/scopes/{scope}",
+        "path": "/scopes/{scope}",
         "method": "GET",
         "title": "List resources for given scope",
         "parameters": {

--- a/api/messaging/spec/permissions.json
+++ b/api/messaging/spec/permissions.json
@@ -20,14 +20,14 @@
       "Name": "list",
       "Method": "GET",
       "Title": "List default permissions",
-      "Path": "/permissions",
+      "Path": "/",
       "Parameters": {}
     },
     {
       "Name": "get",
       "Method": "GET",
       "Title": "Retrieve current permission settings",
-      "Path": "/permissions/{teamID}",
+      "Path": "/{teamID}",
       "Parameters": {
         "get": [
           {
@@ -51,7 +51,7 @@
       "Name": "set",
       "Method": "POST",
       "Title": "Update permission settings",
-      "Path": "/permissions/{teamID}",
+      "Path": "/{teamID}",
       "Parameters": {
         "path": [
           {
@@ -75,7 +75,7 @@
       "Name": "scopes",
       "Method": "GET",
       "Title": "List resources for given scope",
-      "Path": "/permissions/scopes/{scope}",
+      "Path": "/scopes/{scope}",
       "Parameters": {
         "path": [
           {

--- a/docs/messaging/README.md
+++ b/docs/messaging/README.md
@@ -456,7 +456,7 @@ The following event types may be sent with a message event:
 
 | URI | Protocol | Method | Authentication |
 | --- | -------- | ------ | -------------- |
-| `/permissions/permissions` | HTTP/S | GET | Client ID, Session ID |
+| `/permissions/` | HTTP/S | GET | Client ID, Session ID |
 
 #### Request parameters
 
@@ -469,7 +469,7 @@ The following event types may be sent with a message event:
 
 | URI | Protocol | Method | Authentication |
 | --- | -------- | ------ | -------------- |
-| `/permissions/permissions/{teamID}` | HTTP/S | GET | Client ID, Session ID |
+| `/permissions/{teamID}` | HTTP/S | GET | Client ID, Session ID |
 
 #### Request parameters
 
@@ -484,7 +484,7 @@ The following event types may be sent with a message event:
 
 | URI | Protocol | Method | Authentication |
 | --- | -------- | ------ | -------------- |
-| `/permissions/permissions/{teamID}` | HTTP/S | POST | Client ID, Session ID |
+| `/permissions/{teamID}` | HTTP/S | POST | Client ID, Session ID |
 
 #### Request parameters
 
@@ -499,7 +499,7 @@ The following event types may be sent with a message event:
 
 | URI | Protocol | Method | Authentication |
 | --- | -------- | ------ | -------------- |
-| `/permissions/permissions/scopes/{scope}` | HTTP/S | GET | Client ID, Session ID |
+| `/permissions/scopes/{scope}` | HTTP/S | GET | Client ID, Session ID |
 
 #### Request parameters
 

--- a/messaging/rest/handlers/permissions.go
+++ b/messaging/rest/handlers/permissions.go
@@ -78,10 +78,10 @@ func (ph *Permissions) MountRoutes(r chi.Router, middlewares ...func(http.Handle
 	r.Group(func(r chi.Router) {
 		r.Use(middlewares...)
 		r.Route("/permissions", func(r chi.Router) {
-			r.Get("/permissions", ph.List)
-			r.Get("/permissions/{teamID}", ph.Get)
-			r.Post("/permissions/{teamID}", ph.Set)
-			r.Get("/permissions/scopes/{scope}", ph.Scopes)
+			r.Get("/", ph.List)
+			r.Get("/{teamID}", ph.Get)
+			r.Post("/{teamID}", ph.Set)
+			r.Get("/scopes/{scope}", ph.Scopes)
 		})
 	})
 }


### PR DESCRIPTION
Shorten permission path:

```
/permissions/* - with 10 handlers, 3 subroutes
	GET	/permissions/ -> github.com/crusttech/crust/messaging/rest/handlers.NewPermissions.func1
	GET	/permissions/scopes/{scope} -> github.com/crusttech/crust/messaging/rest/handlers.NewPermissions.func4
	POST	/permissions/{teamID} -> github.com/crusttech/crust/messaging/rest/handlers.NewPermissions.func3
	GET	/permissions/{teamID} -> github.com/crusttech/crust/messaging/rest/handlers.NewPermissions.func2
```
instead of:
```
/permissions/* - with 10 handlers, 3 subroutes
	GET	/permissions/permissions -> github.com/crusttech/crust/messaging/rest/handlers.NewPermissions.func1
	GET	/permissions/permissions/scopes/{scope} -> github.com/crusttech/crust/messaging/rest/handlers.NewPermissions.func4
	GET	/permissions/permissions/{teamID} -> github.com/crusttech/crust/messaging/rest/handlers.NewPermissions.func2
	POST	/permissions/permissions/{teamID} -> github.com/crusttech/crust/messaging/rest/handlers.NewPermissions.func3
```