### PR TITLE
rem(messaging) channel update check

### DIFF
--- a/messaging/service/channel.go
+++ b/messaging/service/channel.go
@@ -223,7 +223,7 @@ func (svc *channel) Create(in *types.Channel) (out *types.Channel, err error) {
 			}
 		}
 
-		if in.Topic != "" && !svc.prm.CanUpdate(in) {
+		if in.Topic != "" && false {
 			return errors.New("Not allowed to set channel topic")
 		}
 


### PR DESCRIPTION
At time of creation of channel we do not have resourceID to check this permission. So I removed it for now.