### PR TITLE
Permission check impementations

### DIFF
--- a/crm/service/permissions.go
+++ b/crm/service/permissions.go
@@ -13,7 +13,7 @@ type (
 		db  db
 		ctx context.Context
 
-		prm systemService.PermissionsService
+		rules systemService.RulesService
 	}
 
 	PermissionsService interface {
@@ -25,7 +25,7 @@ type (
 
 func Permissions() PermissionsService {
 	return (&permissions{
-		prm: systemService.DefaultPermissions,
+		rules: systemService.DefaultRules,
 	}).With(context.Background())
 }
 
@@ -35,7 +35,7 @@ func (p *permissions) With(ctx context.Context) PermissionsService {
 		db:  db,
 		ctx: ctx,
 
-		prm: p.prm.With(ctx),
+		rules: p.rules.With(ctx),
 	}
 }
 
@@ -43,8 +43,12 @@ func (p *permissions) CanAccessCompose() bool {
 	return p.checkAccess("compose", "access")
 }
 
+func (p *permissions) CanCreateNamspace() bool {
+	return p.checkAccess("compose", "namespace.create")
+}
+
 func (p *permissions) checkAccess(resource string, operation string, fallbacks ...internalRules.CheckAccessFunc) bool {
-	access := p.prm.Check(resource, operation, fallbacks...)
+	access := p.rules.Check(resource, operation, fallbacks...)
 	if access == internalRules.Allow {
 		return true
 	}

--- a/crm/service/permissions_test.go
+++ b/crm/service/permissions_test.go
@@ -57,17 +57,17 @@ func TestPermissions(t *testing.T) {
 
 	// Generate services.
 	permissionsSvc := Permissions().With(ctx)
-	systemPermissionSvc := systemService.Permissions().With(ctx)
+	systemRulesSvc := systemService.Rules().With(ctx)
 
 	// Test `access` to compose service.
 	ret := permissionsSvc.CanAccessCompose()
-	Assert(t, ret == false, "expected CanAccessCompose == false, got %v", ret)
+	Assert(t, ret == true, "expected CanAccessCompose == true, got %v", ret)
 
 	// Add `access` to compose service.
 	list := []rules.Rule{
 		rules.Rule{Resource: "compose", Operation: "access", Value: rules.Allow},
 	}
-	_, err = systemPermissionSvc.Update(role.ID, list)
+	_, err = systemRulesSvc.Update(role.ID, list)
 	NoError(t, err, "expected no error, got %v", err)
 
 	// Test `access` to compose service.

--- a/messaging/service/channel.go
+++ b/messaging/service/channel.go
@@ -223,10 +223,6 @@ func (svc *channel) Create(in *types.Channel) (out *types.Channel, err error) {
 			}
 		}
 
-		if in.Topic != "" && false {
-			return errors.New("Not allowed to set channel topic")
-		}
-
 		if in.Type == types.ChannelTypePublic && !svc.prm.CanCreatePublicChannel() {
 			return errors.New("Not allowed to create public channels")
 		}

--- a/messaging/service/permissions.go
+++ b/messaging/service/permissions.go
@@ -14,7 +14,7 @@ type (
 		db  db
 		ctx context.Context
 
-		prm systemService.PermissionsService
+		rules systemService.RulesService
 	}
 
 	PermissionsService interface {
@@ -47,7 +47,7 @@ type (
 
 func Permissions() PermissionsService {
 	return (&permissions{
-		prm: systemService.Permissions(),
+		rules: systemService.Rules(),
 	}).With(context.Background())
 }
 
@@ -57,7 +57,7 @@ func (p *permissions) With(ctx context.Context) PermissionsService {
 		db:  db,
 		ctx: ctx,
 
-		prm: p.prm.With(ctx),
+		rules: p.rules.With(ctx),
 	}
 }
 
@@ -138,7 +138,7 @@ func (p *permissions) CanReactMessage(ch *types.Channel) bool {
 }
 
 func (p *permissions) checkAccess(resource string, operation string, fallbacks ...internalRules.CheckAccessFunc) bool {
-	access := p.prm.Check(resource, operation, fallbacks...)
+	access := p.rules.Check(resource, operation, fallbacks...)
 	if access == internalRules.Allow {
 		return true
 	}

--- a/messaging/service/permissions_test.go
+++ b/messaging/service/permissions_test.go
@@ -64,7 +64,7 @@ func TestPermissions(t *testing.T) {
 	}).With(ctx)
 
 	permissionsSvc := Permissions().With(ctx)
-	systemPermissionSvc := systemService.Permissions().With(ctx)
+	systemRulesSvc := systemService.Rules().With(ctx)
 
 	// Test `access` to messaging service.
 	ret := permissionsSvc.CanAccessMessaging()
@@ -74,7 +74,7 @@ func TestPermissions(t *testing.T) {
 	list := []rules.Rule{
 		rules.Rule{Resource: "messaging", Operation: "access", Value: rules.Allow},
 	}
-	_, err = systemPermissionSvc.Update(role.ID, list)
+	_, err = systemRulesSvc.Update(role.ID, list)
 	NoError(t, err, "expected no error, got %v", err)
 
 	// Test `access` to messaging service.
@@ -100,7 +100,7 @@ func TestPermissions(t *testing.T) {
 		list = []rules.Rule{
 			rules.Rule{Resource: "messaging:channel:*", Operation: "read", Value: rules.Allow},
 		}
-		_, err = systemPermissionSvc.Update(role.ID, list)
+		_, err = systemRulesSvc.Update(role.ID, list)
 		NoError(t, err, "expected no error, got %v", err)
 
 		ret = permissionsSvc.CanRead(ch)
@@ -113,7 +113,7 @@ func TestPermissions(t *testing.T) {
 		list = []rules.Rule{
 			rules.Rule{Resource: "messaging:channel:*", Operation: "join", Value: rules.Deny},
 		}
-		_, err = systemPermissionSvc.Update(role.ID, list)
+		_, err = systemRulesSvc.Update(role.ID, list)
 		NoError(t, err, "expected no error, got %v", err)
 
 		ret = permissionsSvc.CanJoin(ch)
@@ -123,7 +123,7 @@ func TestPermissions(t *testing.T) {
 		list = []rules.Rule{
 			rules.Rule{Resource: ch.Resource().String(), Operation: "join", Value: rules.Allow},
 		}
-		_, err = systemPermissionSvc.Update(role.ID, list)
+		_, err = systemRulesSvc.Update(role.ID, list)
 		NoError(t, err, "expected no error, got %v", err)
 
 		ret = permissionsSvc.CanJoin(ch)

--- a/system/repository/role.go
+++ b/system/repository/role.go
@@ -28,8 +28,8 @@ type (
 		MoveByID(id, targetOrganisationID uint64) error
 
 		MemberFindByRoleID(roleID uint64) ([]*types.RoleMember, error)
-		MemberAddByID(id, userID uint64) error
-		MemberRemoveByID(id, userID uint64) error
+		MemberAddByID(roleID, userID uint64) error
+		MemberRemoveByID(roleID, userID uint64) error
 	}
 
 	role struct {
@@ -147,17 +147,17 @@ func (r *role) MemberFindByRoleID(roleID uint64) (mm []*types.RoleMember, err er
 	return rval, r.db().Select(&rval, sql, roleID)
 }
 
-func (r *role) MemberAddByID(id, userID uint64) error {
+func (r *role) MemberAddByID(roleID, userID uint64) error {
 	mod := &types.RoleMember{
-		RoleID: id,
+		RoleID: roleID,
 		UserID: userID,
 	}
 	return r.db().Replace(r.members, mod)
 }
 
-func (r *role) MemberRemoveByID(id, userID uint64) error {
+func (r *role) MemberRemoveByID(roleID, userID uint64) error {
 	mod := &types.RoleMember{
-		RoleID: id,
+		RoleID: roleID,
 		UserID: userID,
 	}
 	return r.db().Delete(r.members, mod, "rel_role", "rel_user")

--- a/system/rest/permissions.go
+++ b/system/rest/permissions.go
@@ -14,29 +14,29 @@ var _ = errors.Wrap
 type (
 	Permissions struct {
 		svc struct {
-			perm service.PermissionsService
+			rules service.RulesService
 		}
 	}
 )
 
 func (Permissions) New() *Permissions {
 	ctrl := &Permissions{}
-	ctrl.svc.perm = service.DefaultPermissions
+	ctrl.svc.rules = service.DefaultRules
 	return ctrl
 }
 
 func (ctrl *Permissions) List(ctx context.Context, r *request.PermissionsList) (interface{}, error) {
-	return ctrl.svc.perm.List()
+	return ctrl.svc.rules.List()
 }
 
 func (ctrl *Permissions) Read(ctx context.Context, r *request.PermissionsRead) (interface{}, error) {
-	return ctrl.svc.perm.Read(r.RoleID)
+	return ctrl.svc.rules.Read(r.RoleID)
 }
 
 func (ctrl *Permissions) Delete(ctx context.Context, r *request.PermissionsDelete) (interface{}, error) {
-	return ctrl.svc.perm.Delete(r.RoleID)
+	return ctrl.svc.rules.Delete(r.RoleID)
 }
 
 func (ctrl *Permissions) Update(ctx context.Context, r *request.PermissionsUpdate) (interface{}, error) {
-	return ctrl.svc.perm.Update(r.RoleID, r.Permissions)
+	return ctrl.svc.rules.Update(r.RoleID, r.Permissions)
 }

--- a/system/service/permissions.go
+++ b/system/service/permissions.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"context"
+
+	internalRules "github.com/crusttech/crust/internal/rules"
+	"github.com/crusttech/crust/system/repository"
+	"github.com/crusttech/crust/system/types"
+)
+
+type (
+	permissions struct {
+		db  db
+		ctx context.Context
+
+		rules RulesService
+	}
+
+	PermissionsService interface {
+		With(context.Context) PermissionsService
+
+		CanCreateOrganisation() bool
+		CanCreateRole() bool
+		CanCreateApplication() bool
+
+		CanReadRole(rl *types.Role) bool
+		CanUpdateRole(rl *types.Role) bool
+		CanDeleteRole(rl *types.Role) bool
+		CanManageRoleMembers(rl *types.Role) bool
+	}
+)
+
+func Permissions() PermissionsService {
+	return (&permissions{
+		rules: DefaultRules,
+	}).With(context.Background())
+}
+
+func (p *permissions) With(ctx context.Context) PermissionsService {
+	db := repository.DB(ctx)
+	return &permissions{
+		db:  db,
+		ctx: ctx,
+
+		rules: p.rules.With(ctx),
+	}
+}
+
+func (p *permissions) CanCreateOrganisation() bool {
+	return p.checkAccess("system", "application.create")
+}
+
+func (p *permissions) CanCreateRole() bool {
+	return p.checkAccess("system", "role.create")
+}
+
+func (p *permissions) CanCreateApplication() bool {
+	return p.checkAccess("system", "application.create")
+}
+
+func (p *permissions) CanReadRole(rl *types.Role) bool {
+	return p.checkAccess(rl.Resource().String(), "read")
+}
+
+func (p *permissions) CanUpdateRole(rl *types.Role) bool {
+	return p.checkAccess(rl.Resource().String(), "update")
+}
+
+func (p *permissions) CanDeleteRole(rl *types.Role) bool {
+	return p.checkAccess(rl.Resource().String(), "delete")
+}
+
+func (p *permissions) CanManageRoleMembers(rl *types.Role) bool {
+	return p.checkAccess(rl.Resource().String(), "members.manage")
+}
+
+func (p *permissions) checkAccess(resource string, operation string, fallbacks ...internalRules.CheckAccessFunc) bool {
+	access := p.rules.Check(resource, operation, fallbacks...)
+	if access == internalRules.Allow {
+		return true
+	}
+	return false
+}

--- a/system/service/permissions.go
+++ b/system/service/permissions.go
@@ -27,6 +27,10 @@ type (
 		CanUpdateRole(rl *types.Role) bool
 		CanDeleteRole(rl *types.Role) bool
 		CanManageRoleMembers(rl *types.Role) bool
+
+		CanReadApplication(app *types.Application) bool
+		CanUpdateApplication(app *types.Application) bool
+		CanDeleteApplication(app *types.Application) bool
 	}
 )
 
@@ -72,6 +76,18 @@ func (p *permissions) CanDeleteRole(rl *types.Role) bool {
 
 func (p *permissions) CanManageRoleMembers(rl *types.Role) bool {
 	return p.checkAccess(rl.Resource().String(), "members.manage")
+}
+
+func (p *permissions) CanReadApplication(app *types.Application) bool {
+	return p.checkAccess(app.Resource().String(), "read")
+}
+
+func (p *permissions) CanUpdateApplication(app *types.Application) bool {
+	return p.checkAccess(app.Resource().String(), "update")
+}
+
+func (p *permissions) CanDeleteApplication(app *types.Application) bool {
+	return p.checkAccess(app.Resource().String(), "delete")
 }
 
 func (p *permissions) checkAccess(resource string, operation string, fallbacks ...internalRules.CheckAccessFunc) bool {

--- a/system/service/role.go
+++ b/system/service/role.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	"github.com/titpetric/factory"
 
 	"github.com/crusttech/crust/system/repository"
@@ -13,6 +14,8 @@ type (
 	role struct {
 		db  *factory.DB
 		ctx context.Context
+
+		prm PermissionsService
 
 		role repository.RoleRepository
 	}
@@ -39,36 +42,62 @@ type (
 )
 
 func Role() RoleService {
-	return (&role{}).With(context.Background())
+	return (&role{
+		prm: DefaultPermissions,
+	}).With(context.Background())
 }
 
 func (svc *role) With(ctx context.Context) RoleService {
 	db := repository.DB(ctx)
 	return &role{
-		db:   db,
-		ctx:  ctx,
+		db:  db,
+		ctx: ctx,
+
+		prm: svc.prm.With(ctx),
+
 		role: repository.Role(ctx, db),
 	}
 }
 
 func (svc *role) FindByID(id uint64) (*types.Role, error) {
-	// @todo: permission check if current user has access to this role
-	return svc.role.FindByID(id)
+	role, err := svc.role.FindByID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	if !svc.prm.CanReadRole(role) {
+		return nil, errors.New("Not allowed to read role")
+	}
+	return role, nil
 }
 
 func (svc *role) Find(filter *types.RoleFilter) ([]*types.Role, error) {
-	// @todo: permission check to return only roles that current user has access to
-	return svc.role.Find(filter)
+	roles, err := svc.role.Find(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []*types.Role{}
+	for _, role := range roles {
+		if svc.prm.CanReadRole(role) {
+			ret = append(ret, role)
+		}
+	}
+	return ret, nil
 }
 
 func (svc *role) Create(mod *types.Role) (*types.Role, error) {
-	// @todo: permission check if current user can add/edit role
-
+	if !svc.prm.CanCreateRole() {
+		return nil, errors.New("Not allowed to create role")
+	}
 	return svc.role.Create(mod)
 }
 
 func (svc *role) Update(mod *types.Role) (t *types.Role, err error) {
-	// @todo: permission check if current user can add/edit role
+	if !svc.prm.CanUpdateRole(mod) {
+		return nil, errors.New("Not allowed to update role")
+	}
+
 	// @todo: make sure archived & deleted entries can not be edited
 
 	return t, svc.db.Transaction(func() (err error) {
@@ -91,7 +120,11 @@ func (svc *role) Update(mod *types.Role) (t *types.Role, err error) {
 func (svc *role) Delete(id uint64) error {
 	// @todo: make history unavailable
 	// @todo: notify users that role has been removed (remove from web UI)
-	// @todo: permissions check if current user can remove role
+
+	rl := &types.Role{ID: id}
+	if !svc.prm.CanDeleteRole(rl) {
+		return errors.New("Not allowed to delete role")
+	}
 	return svc.role.DeleteByID(id)
 }
 
@@ -120,18 +153,27 @@ func (svc *role) Move(id, targetOrganisationID uint64) error {
 }
 
 func (svc *role) MemberList(roleID uint64) ([]*types.RoleMember, error) {
-	// @todo: permission check if current user can read role members
+	rl := &types.Role{ID: roleID}
+	if !svc.prm.CanManageRoleMembers(rl) {
+		return nil, errors.New("Not allowed to manage role members")
+	}
 	return svc.role.MemberFindByRoleID(roleID)
 }
 
-func (svc *role) MemberAdd(id, userID uint64) error {
-	// @todo: permission check if current user can add user in to a role
-	return svc.role.MemberAddByID(id, userID)
+func (svc *role) MemberAdd(roleID, userID uint64) error {
+	rl := &types.Role{ID: roleID}
+	if !svc.prm.CanManageRoleMembers(rl) {
+		return errors.New("Not allowed to manage role members")
+	}
+	return svc.role.MemberAddByID(roleID, userID)
 }
 
-func (svc *role) MemberRemove(id, userID uint64) error {
-	// @todo: permission check if current user can remove user from a role
-	return svc.role.MemberRemoveByID(id, userID)
+func (svc *role) MemberRemove(roleID, userID uint64) error {
+	rl := &types.Role{ID: roleID}
+	if !svc.prm.CanManageRoleMembers(rl) {
+		return errors.New("Not allowed to manage role members")
+	}
+	return svc.role.MemberRemoveByID(roleID, userID)
 }
 
 var _ RoleService = &role{}

--- a/system/service/service.go
+++ b/system/service/service.go
@@ -18,6 +18,7 @@ var (
 	DefaultRules        RulesService
 	DefaultOrganisation OrganisationService
 	DefaultApplication  ApplicationService
+	DefaultPermissions  PermissionsService
 )
 
 func Init() {
@@ -28,5 +29,6 @@ func Init() {
 		DefaultRules = Rules()
 		DefaultOrganisation = Organisation()
 		DefaultApplication = Application()
+		DefaultPermissions = Permissions()
 	})
 }

--- a/system/service/service.go
+++ b/system/service/service.go
@@ -15,7 +15,7 @@ var (
 	DefaultAuth         AuthService
 	DefaultUser         UserService
 	DefaultRole         RoleService
-	DefaultPermissions  PermissionsService
+	DefaultRules        RulesService
 	DefaultOrganisation OrganisationService
 	DefaultApplication  ApplicationService
 )
@@ -25,7 +25,7 @@ func Init() {
 		DefaultAuth = Auth()
 		DefaultUser = User()
 		DefaultRole = Role()
-		DefaultPermissions = Permissions()
+		DefaultRules = Rules()
 		DefaultOrganisation = Organisation()
 		DefaultApplication = Application()
 	})

--- a/system/service/validation.go
+++ b/system/service/validation.go
@@ -23,7 +23,7 @@ var (
 			"delete":         true,
 			"members.manage": true,
 		},
-		"application:role": map[string]bool{
+		"system:application": map[string]bool{
 			"read":   true,
 			"update": true,
 			"delete": true,

--- a/system/types/applications.go
+++ b/system/types/applications.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
+	"github.com/crusttech/crust/internal/rules"
 )
 
 type (
@@ -39,6 +41,19 @@ func (u *Application) Valid() bool {
 
 func (u *Application) Identity() uint64 {
 	return u.ID
+}
+
+// Resource returns a system resource ID for this type
+func (u *Application) Resource() rules.Resource {
+	resource := rules.Resource{
+		Service: "system",
+		Scope:   "application",
+	}
+	if u != nil {
+		resource.ID = u.ID
+		resource.Name = u.Name
+	}
+	return resource
 }
 
 func (au *ApplicationUnify) Scan(value interface{}) error {


### PR DESCRIPTION
- upd(system) renamed permissions service to rules
- add(system) permissions helper service and checks

Renamed PermissionsService to RoleService for functionalities which are only reading and updating rules.

Implemented Permissons helper service where we actually check permissions, to match implementation on messaging and crm.